### PR TITLE
Avoid checked exception in init()

### DIFF
--- a/generators/server/templates/src/main/java/package/config/UaaWebSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/UaaWebSecurityConfiguration.java.ejs
@@ -48,11 +48,16 @@ public class UaaWebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @PostConstruct
     public void init() throws Exception {
-        authenticationManagerBuilder
-            .userDetailsService(userDetailsService)
-            .passwordEncoder(passwordEncoder());
+        try {
+            authenticationManagerBuilder
+                .userDetailsService(userDetailsService)
+                .passwordEncoder(passwordEncoder());
+        } catch (Exception e) {
+            throw new BeanInitializationException("Security configuration failed", e);
+        }
     }
-
+    
+ 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();


### PR DESCRIPTION
The init() method should not throw a checked exception since it is annotated with @PostConstruct. Le´ts borrow the code from SecurityConfiguration to avoid this.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
